### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ worksheet.commit()
 Documentation
 -------------
 
-Documentation is available at https://hyou.readthedocs.org/.
+Documentation is available at https://hyou.readthedocs.io/.
 
 
 Author

--- a/README.txt
+++ b/README.txt
@@ -38,7 +38,7 @@ Synopsis
 Documentation
 -------------
 
-Documentation is available at https://hyou.readthedocs.org/.
+Documentation is available at https://hyou.readthedocs.io/.
 
 Author
 ------


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
